### PR TITLE
Change api-extractor entry point from dist/esm/index.d.ts to dist/index.d.ts

### DIFF
--- a/api-extractor.json
+++ b/api-extractor.json
@@ -3,7 +3,7 @@
  */
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "mainEntryPointFilePath": "<projectFolder>/dist/esm/index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/dist/index.d.ts",
   "apiReport": {
     "enabled": true,
     "reportFolder": "<projectFolder>/api-extractor"


### PR DESCRIPTION
This is part of a general change across our projects to move from hybrid CJS + ESM builds to CJS-only (until ESM is fully supported across all tooling)