### PR TITLE
Target ES2019 in both CJS and ESM configs

### DIFF
--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -8,6 +8,7 @@
     "incremental": true,
     "jsx": "react",
     "moduleResolution": "Node",
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "target": "ES2019"
   }
 }

--- a/tsconfig-cjs.json
+++ b/tsconfig-cjs.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig-base.json",
   "compilerOptions": {
-    "module": "CommonJS",
-    "target": "ES5"
+    "module": "CommonJS"
   }
 }

--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig-base.json",
   "compilerOptions": {
-    "module": "ES2015",
-    "target": "ES2019"
+    "module": "ES2015"
   }
 }


### PR DESCRIPTION
This is part of a general change across our projects to move from hybrid CJS + ESM builds to CJS-only (until ESM is fully supported across all tooling)

Closes #9